### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### `Send Tags Takehome - Deadline/Due: Friday, 9.4.20 5:00 PT` 
 
-At Noterouter, we use attributed such as tags, organization, or names that are assigned to our clients' recipients in order determine who we want to send messages to. For this takehome, we created a rudimentary sending system for you to finish and implement.
+At Noterouter, we use attributes such as tags, organization, or names that are assigned to our clients' recipients in order determine who we want to send messages to. For this takehome, we created a rudimentary sending system for you to finish and implement.
 
 This React App is partially implemented with the following inputs defined:
 


### PR DESCRIPTION
I think it's supposed to be attributes rather than attributed on line 3

I was unable to make the time to do this assessment, but here's a free readme typo fix for you!